### PR TITLE
Enhance site structure and styling

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'About - Project Prometheus',
+  description: 'Learn about Elias Rittenhouse and the mission of Project Prometheus.'
+};
 
 export default function About(): ReactElement {
   return (

--- a/src/app/api/newsletter/route.ts
+++ b/src/app/api/newsletter/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  // Placeholder for future newsletter integration
+  return NextResponse.json({ success: true })
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,11 @@
 import posts from '../../posts.json';
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Blog - Project Prometheus',
+  description: 'Campaign updates and thoughts from Elias Rittenhouse.'
+};
 
 export default function Blog(): ReactElement {
   return (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,36 +1,12 @@
-'use client'
-import { useState } from 'react'
+import type { Metadata } from 'next'
 import type { ReactElement } from 'react'
+import ContactForm from '../../components/ContactForm'
+
+export const metadata: Metadata = {
+  title: 'Contact - Project Prometheus',
+  description: 'Reach out to Elias Rittenhouse and the campaign team.'
+}
 
 export default function Contact(): ReactElement {
-  const [submitted, setSubmitted] = useState(false)
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    await fetch('/api/contact', {
-      method: 'POST',
-      body: JSON.stringify({
-        name: formData.get('name'),
-        email: formData.get('email'),
-        message: formData.get('message'),
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-    setSubmitted(true)
-  }
-
-  if (submitted) {
-    return <p className="p-8 text-center">Message sent. Thank you!</p>
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="p-8 max-w-md mx-auto space-y-4">
-      <h1 className="text-3xl font-bold mb-4">Contact</h1>
-      <input name="name" required placeholder="Name" className="w-full p-2 border" />
-      <input name="email" required type="email" placeholder="Email" className="w-full p-2 border" />
-      <textarea name="message" required placeholder="Message" className="w-full p-2 border" />
-      <button type="submit" className="bg-fireorange text-softwhite px-4 py-2 rounded">Send</button>
-    </form>
-  )
+  return <ContactForm />
 }

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Donate - Project Prometheus',
+  description: 'Support the campaign once FEC registration is complete.'
+};
 
 export default function Donate(): ReactElement {
   return (

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,36 +1,12 @@
-'use client'
-import { useState } from 'react'
+import type { Metadata } from 'next'
 import type { ReactElement } from 'react'
+import VolunteerForm from '../../components/VolunteerForm'
+
+export const metadata: Metadata = {
+  title: 'Get Involved - Project Prometheus',
+  description: 'Volunteer and join Elias Rittenhouse in the fight for a brighter future.'
+}
 
 export default function GetInvolved(): ReactElement {
-  const [submitted, setSubmitted] = useState(false)
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    await fetch('/api/contact', {
-      method: 'POST',
-      body: JSON.stringify({
-        name: formData.get('name'),
-        email: formData.get('email'),
-        message: formData.get('message'),
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-    setSubmitted(true)
-  }
-
-  if (submitted) {
-    return <p className="p-8 text-center">Thank you for volunteering!</p>
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="p-8 max-w-md mx-auto space-y-4">
-      <h1 className="text-3xl font-bold mb-4">Get Involved</h1>
-      <input name="name" required placeholder="Name" className="w-full p-2 border" />
-      <input name="email" required type="email" placeholder="Email" className="w-full p-2 border" />
-      <textarea name="message" placeholder="How can you help?" className="w-full p-2 border" />
-      <button type="submit" className="bg-fireorange text-softwhite px-4 py-2 rounded">Volunteer</button>
-    </form>
-  )
+  return <VolunteerForm />
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -18,6 +18,11 @@
   }
 }
 
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, Montserrat } from "next/font/google";
 import Link from "next/link";
 import type { ReactElement } from "react";
+import ThemeToggle from "../components/ThemeToggle";
 import "./global.css";
 
 const inter = Inter({
@@ -53,15 +54,16 @@ export default function RootLayout({
       <body className={`${inter.variable} ${montserrat.variable} antialiased`}>
         <header className="bg-charcoal text-softwhite p-4 flex justify-between items-center">
           <Link href="/" className="text-xl font-bold">Project Prometheus</Link>
-          <nav className="space-x-4">
+          <nav className="space-x-4 flex items-center">
             <a href="/about" className="hover:text-fireorange">About</a>
             <a href="/platform" className="hover:text-fireorange">Platform</a>
             <a href="/get-involved" className="hover:text-fireorange">Get Involved</a>
-            <a href="/donate" className="hover:text-fireorange">Donate</a>
+            <button disabled title="Coming Soon after FEC registration" className="hover:text-fireorange cursor-not-allowed opacity-70">Donate</button>
             <a href="/blog" className="hover:text-fireorange">Blog</a>
             <a href="/media-kit" className="hover:text-fireorange">Media Kit</a>
             <a href="/quotes" className="hover:text-fireorange">Quotes</a>
             <a href="/contact" className="hover:text-fireorange">Contact</a>
+            <ThemeToggle />
           </nav>
         </header>
         <main className="min-h-[calc(100vh-4rem)]">{children}</main>

--- a/src/app/media-kit/page.tsx
+++ b/src/app/media-kit/page.tsx
@@ -1,4 +1,12 @@
-export default function MediaKit() {
+import type { Metadata } from 'next'
+import type { ReactElement } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Media Kit - Project Prometheus',
+  description: 'Official campaign logos and materials for press use.'
+}
+
+export default function MediaKit(): ReactElement {
   return (
     <div className="p-8 max-w-3xl mx-auto space-y-6">
       <h1 className="text-3xl font-bold mb-4">Media Kit</h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,50 @@
 import NewsletterSignup from '../components/NewsletterSignup';
 import CampaignBadge from '../components/CampaignBadge';
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Project Prometheus: Elias 2026',
+  description: 'For my sons. For the people. For the flame.',
+  openGraph: {
+    title: 'Project Prometheus: Elias 2026',
+    description: 'For my sons. For the people. For the flame.',
+    url: 'https://example.com',
+    siteName: 'Project Prometheus',
+  },
+};
 
 export default function Home(): ReactElement {
   return (
-    <section className="flex flex-col items-center justify-center py-20 text-center bg-[url('/globe.svg')] bg-cover bg-center space-y-8">
-      <div>
-        <h1 className="text-4xl sm:text-5xl font-bold mb-6">Project Prometheus: Elias 2026 — Ignite the Future</h1>
-        <p className="max-w-xl mb-8">Join Elias Rittenhouse in lighting the way toward a just, transparent, and technology-empowered future.</p>
-        <div className="space-x-4 mb-8">
-          <a href="/platform" className="bg-fireorange text-softwhite px-6 py-3 rounded hover:bg-emberred transition">Explore the Platform</a>
-          <a href="/donate" className="bg-softwhite text-charcoal px-6 py-3 rounded hover:bg-fireorange hover:text-softwhite transition">Donate</a>
+    <>
+      <section className="flex flex-col items-center justify-center py-20 text-center bg-[url('/globe.svg')] bg-cover bg-center space-y-8">
+        <div>
+          <h1 className="text-4xl sm:text-5xl font-bold mb-6">Project Prometheus: Elias 2026 — Ignite the Future</h1>
+          <p className="max-w-xl mb-8">Join Elias Rittenhouse in lighting the way toward a just, transparent, and technology-empowered future.</p>
+          <div className="space-x-4 mb-8">
+            <a href="/platform" className="bg-fireorange text-softwhite px-6 py-3 rounded hover:bg-emberred transition">Explore the Platform</a>
+            <button disabled title="Coming Soon after FEC registration" className="bg-softwhite text-charcoal px-6 py-3 rounded cursor-not-allowed opacity-70">Donate</button>
+          </div>
+          <NewsletterSignup />
         </div>
-        <NewsletterSignup />
-      </div>
-      <CampaignBadge />
-    </section>
+        <CampaignBadge />
+      </section>
+
+      <section className="p-8 max-w-4xl mx-auto flex flex-col md:flex-row items-center gap-6">
+        <img src="https://via.placeholder.com/300x200" alt="Elias after a long day's work" className="w-full md:w-1/2 rounded" />
+        <div>
+          <h2 className="text-2xl font-bold mb-2">Why I’m Running</h2>
+          <blockquote className="italic mb-4">“Placeholder quote about perseverance and serving the community after a long day’s work.”</blockquote>
+          <p>Placeholder text sharing Elias’s motivation for entering the race and his dedication to working people.</p>
+        </div>
+      </section>
+
+      <section className="p-8 max-w-4xl mx-auto space-y-4 text-center">
+        <h2 className="text-2xl font-bold">Message from Elias</h2>
+        <div className="relative pb-[56.25%] h-0">
+          <iframe className="absolute top-0 left-0 w-full h-full" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Video message" allowFullScreen></iframe>
+        </div>
+      </section>
+    </>
   );
 }

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -21,7 +21,13 @@ const pillars = [
   },
 ];
 
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Platform - Project Prometheus',
+  description: 'Elias Rittenhouse\'s vision for anti-corruption, healthcare, tech, and transparency.'
+};
 
 export default function Platform(): ReactElement {
   return (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - Project Prometheus',
+  description: 'How we handle your data on the campaign site.'
+};
 
 export default function Privacy(): ReactElement {
   return (

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -1,36 +1,12 @@
-'use client'
-import { useState } from 'react';
-import type { ReactElement } from 'react';
+import type { Metadata } from 'next'
+import type { ReactElement } from 'react'
+import QuotesGallery from '../../components/QuotesGallery'
 
-const cards = [
-  { name: 'Ignite', file: '/quotes/ignite.svg' },
-];
+export const metadata: Metadata = {
+  title: 'Quotes - Project Prometheus',
+  description: 'Download and share quotes from Elias Rittenhouse.'
+}
 
 export default function Quotes(): ReactElement {
-  const [copied, setCopied] = useState<string | null>(null);
-
-  function copy(url: string) {
-    navigator.clipboard.writeText(window.location.origin + url);
-    setCopied(url);
-    setTimeout(() => setCopied(null), 2000);
-  }
-
-  return (
-    <div className="p-8 max-w-3xl mx-auto space-y-6">
-      <h1 className="text-3xl font-bold mb-6">Shareable Quotes</h1>
-      <div className="grid sm:grid-cols-2 gap-6">
-        {cards.map((card) => (
-          <div key={card.name} className="border p-4 rounded text-center">
-            <img src={card.file} alt={card.name} className="mx-auto mb-2" />
-            <div className="space-x-2">
-              <a href={card.file} download className="underline text-fireorange">Download</a>
-              <button onClick={() => copy(card.file)} className="underline text-fireorange">
-                {copied === card.file ? 'Copied!' : 'Copy Link'}
-              </button>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <QuotesGallery />
 }

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+
+export default function ContactForm(): ReactElement {
+  const [submitted, setSubmitted] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    await fetch('/api/contact', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: formData.get('name'),
+        email: formData.get('email'),
+        message: formData.get('message'),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    setSubmitted(true)
+  }
+
+  if (submitted) {
+    return <p className="p-8 text-center">Message sent. Thank you!</p>
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-8 max-w-md mx-auto space-y-4">
+      <h1 className="text-3xl font-bold mb-4">Contact</h1>
+      <input name="name" required placeholder="Name" className="w-full p-2 border" />
+      <input name="email" required type="email" placeholder="Email" className="w-full p-2 border" />
+      <textarea name="message" required placeholder="Message" className="w-full p-2 border" />
+      <button type="submit" className="bg-fireorange text-softwhite px-4 py-2 rounded">Send</button>
+    </form>
+  )
+}

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -8,7 +8,11 @@ export default function NewsletterSignup(): ReactElement {
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    // Placeholder for Mailchimp integration
+    await fetch('/api/newsletter', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
     setSubmitted(true);
   }
 

--- a/src/components/QuotesGallery.tsx
+++ b/src/components/QuotesGallery.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+
+const cards = [
+  { name: 'Ignite', file: '/quotes/ignite.svg' },
+]
+
+export default function QuotesGallery(): ReactElement {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  function copy(url: string) {
+    navigator.clipboard.writeText(window.location.origin + url)
+    setCopied(url)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
+      <h1 className="text-3xl font-bold mb-6">Shareable Quotes</h1>
+      <div className="grid sm:grid-cols-2 gap-6">
+        {cards.map((card) => (
+          <div key={card.name} className="border p-4 rounded text-center">
+            <img src={card.file} alt={card.name} className="mx-auto mb-2" />
+            <div className="space-x-2">
+              <a href={card.file} download className="underline text-fireorange">Download</a>
+              <button onClick={() => copy(card.file)} className="underline text-fireorange">
+                {copied === card.file ? 'Copied!' : 'Copy Link'}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { useEffect, useState } from 'react'
+import type { ReactElement } from 'react'
+
+export default function ThemeToggle(): ReactElement {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (enabled) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [enabled])
+
+  return (
+    <button
+      onClick={() => setEnabled(!enabled)}
+      className="px-2 py-1 border rounded hover:bg-charcoal hover:text-softwhite dark:bg-softwhite dark:text-charcoal"
+      aria-label="Toggle dark mode"
+    >
+      {enabled ? 'Light' : 'Dark'}
+    </button>
+  )
+}

--- a/src/components/VolunteerForm.tsx
+++ b/src/components/VolunteerForm.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+
+export default function VolunteerForm(): ReactElement {
+  const [submitted, setSubmitted] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    await fetch('/api/contact', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: formData.get('name'),
+        email: formData.get('email'),
+        message: formData.get('message'),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    setSubmitted(true)
+  }
+
+  if (submitted) {
+    return <p className="p-8 text-center">Thank you for volunteering!</p>
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-8 max-w-md mx-auto space-y-4">
+      <h1 className="text-3xl font-bold mb-4">Get Involved</h1>
+      <input name="name" required placeholder="Name" className="w-full p-2 border" />
+      <input name="email" required type="email" placeholder="Email" className="w-full p-2 border" />
+      <textarea name="message" placeholder="How can you help?" className="w-full p-2 border" />
+      <button type="submit" className="bg-fireorange text-softwhite px-4 py-2 rounded">Volunteer</button>
+    </form>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
@@ -15,6 +16,6 @@ const config: Config = {
     },
   },
   plugins: [],
-}
+};
 
-export default config
+export default config;


### PR DESCRIPTION
## Summary
- add placeholder newsletter API route
- implement dark mode toggle
- disable Donate links until FEC registration
- create hero sub-sections and video message embed
- create client form components
- add SEO metadata on all pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888083343ec83308d4046083026b702